### PR TITLE
plugin.yml missing from NMSUtils-Plugin

### DIFF
--- a/NMSUtils-plugin/plugin.yml
+++ b/NMSUtils-plugin/plugin.yml
@@ -1,0 +1,5 @@
+name: NMSUtils
+main: net.tangentmc.nmsutils.NMSUtils
+version: ${project.version}
+authors: [matejdro, oliverw92, V10lator, sanjay900]
+depend: [ProtocolLib]


### PR DESCRIPTION
plugin will not load on server without the plugin.yml, this fixes the issue upon compile.